### PR TITLE
Go back to a checkbox option

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -376,7 +376,7 @@ class FrozenCLIPEmbedderWithCustomWords(torch.nn.Module):
 
     def process_tokens(self, remade_batch_tokens, batch_multipliers):
         if not opts.use_old_emphasis_implementation:
-            remade_batch_tokens = [[self.id_sot] + x[:76] + [self.id_fill] for x in remade_batch_tokens]
+            remade_batch_tokens = [[self.id_sot] + x[:75] + [self.id_fill] for x in remade_batch_tokens]
             batch_multipliers = [[1.0] + x[:75] + [1.0] for x in batch_multipliers]
 
         if hasattr(self.wrapped, "transformer"):

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -266,7 +266,7 @@ def load_model(checkpoint_info=None):
     
     # check if the model uses v-prediction (the 768x768 model and x4 upscaler do)
     # see https://arxiv.org/abs/2202.00512
-    shared.v_prediction = sd_config.model.params.get("parameterization") == "v"
+    shared.opts.v_sampling = sd_config.model.params.get("parameterization") == "v"
 
     if should_hijack_inpainting(checkpoint_info):
         # Hardcoded config for now...

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -352,7 +352,7 @@ class TorchHijack:
 
 class KDiffusionSampler:
     def __init__(self, funcname, sd_model):
-        wrapper = k_diffusion.external.CompVisVDenoiser if shared.v_prediction else k_diffusion.external.CompVisDenoiser
+        wrapper = k_diffusion.external.CompVisVDenoiser if shared.opts.v_sampling else k_diffusion.external.CompVisDenoiser
         self.model_wrap = wrapper(sd_model, quantize=shared.opts.enable_quantization)
         self.funcname = funcname
         self.func = getattr(k_diffusion.sampling, self.funcname)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -124,8 +124,6 @@ os.makedirs(cmd_opts.hypernetwork_dir, exist_ok=True)
 hypernetworks = hypernetwork.list_hypernetworks(cmd_opts.hypernetwork_dir)
 loaded_hypernetwork = None
 
-v_prediction = False
-
 def reload_hypernetworks():
     global hypernetworks
 
@@ -395,6 +393,7 @@ options_templates.update(options_section(('sampler-params', "Sampler parameters"
     's_tmin':  OptionInfo(0.0, "sigma tmin",  gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
     's_noise': OptionInfo(1.0, "sigma noise", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
     'eta_noise_seed_delta': OptionInfo(0, "Eta noise seed delta", gr.Number, {"precision": 0}),
+    "v_sampling": OptionInfo(False, "Use v-prediction"),
 }))
 
 options_templates.update(options_section((None, "Hidden options"), {


### PR DESCRIPTION
Certain custom built models like this dreambooth https://old.reddit.com/r/StableDiffusion/comments/z42idl/new_release_sd_20_dreambooth_model_futurediffusion/ are not automatically assigned the correct prediction mode so it's useful to have an override option.